### PR TITLE
Don't actually install gems 😀

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -32,16 +32,13 @@ fi
 
 gem install bundler-diff
 
-bundle config --local build.mysql2 "--with-ldflags=-L/usr/local/opt/openssl/lib"
-bundle config --local build.nokogiri "--with-xml2-dir=/usr --with-xslt-dir=/opt/local --with-iconv-dir=/opt/local"
-
 if [[ -n "$INPUT_JFROG_PATH" ]]; then
   gem update --system 3.1.1 > /dev/null
   bundle config set --global $INPUT_JFROG_PATH $INPUT_JFROG_USERNAME:$INPUT_JFROG_API_TOKEN
 fi
 
 
-bundle update
+bundle lock --update
 bundle diff -f md_table
 BUNDLE_DIFF="$(bundle diff -f md_table)"
 


### PR DESCRIPTION
`bundle lock --update` pretty much does what `bundle install` does, except it doesn't actually "install". ([bundle lock docs](https://bundler.io/v2.1/man/bundle-lock.1.html))

This is good in this scenario because we're just generating a Gemfile.lock. The installing isn't necessary (so takes extra time) and introduces a game of compilation whack-a-mole where you potentially have to add in configurations for each compiling app.
