### PR TITLE
Install yarn via apk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,9 @@ RUN echo http://dl-cdn.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositor
   mariadb-dev \
   postgresql-dev
 
-RUN npm i -g --force yarn
+RUN apk add yarn && \
+  echo $(yarn --version)
+
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 


### PR DESCRIPTION
Builds are blowing up because `npm` is not available. Took this from the yarn docs: https://classic.yarnpkg.com/en/docs/install/#alpine-stable