### PR TITLE
Get default branch name from remote

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,7 +18,8 @@ if [[ -z "$GIT_EMAIL" ]]; then
 fi
 
 git remote set-url origin "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY"
-git checkout master
+DEFAULT_BRANCH=git remote show $REMOTE | grep "HEAD branch" | sed 's/.*: //'
+git checkout ${DEFAULT_BRANCH}
 BRANCH_NAME="bundle_update/$(date "+%Y%m%d_%H%M%S")"
 git checkout -b ${BRANCH_NAME}
 


### PR DESCRIPTION
## Problem

This script only works for repos that use `master` as the default branch.

## Solution

Get the default branch name from the remote