### PR TITLE
Hard-code reference to origin remote

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,7 +18,7 @@ if [[ -z "$GIT_EMAIL" ]]; then
 fi
 
 git remote set-url origin "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY"
-DEFAULT_BRANCH=$(git remote show $REMOTE | grep "HEAD branch" | sed 's/.*: //')
+DEFAULT_BRANCH=$(git remote show origin | grep "HEAD branch" | sed 's/.*: //')
 git checkout ${DEFAULT_BRANCH}
 BRANCH_NAME="bundle_update/$(date "+%Y%m%d_%H%M%S")"
 git checkout -b ${BRANCH_NAME}


### PR DESCRIPTION
$REMOTE is not configured to be available when this action runs, meaning that `$DEFAULT_BRANCH` is unset. This causes hub to run a command with a blank base branch, triggering this error:

```
Error creating pull request: Unprocessable Entity (HTTP 422)
Invalid value for "base"
```

As other parts of this script also have dependencies on `origin`, This PR switches to a hard-coded `origin` instead of adding the wiring to support configuring `$REMOTE`.